### PR TITLE
Correct description of npm. Not an acronym.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ I still think the easiest way to learn React is [the official tutorial](https://
 
 ## Learning `npm`
 
-`npm` stands for *Node.js package manager* and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` (Google it -- it’s important) and lets you install command-line tools written in JavaScript.
+`npm` is the Node.js package manager and is the most popular way front-end engineers and designers share JavaScript code. It includes a module system called `CommonJS` (Google it -- it’s important) and lets you install command-line tools written in JavaScript.
 
 Most reusable components, libraries and tools in the React ecosystem are available as `CommonJS` modules and are installed with `npm`.
 


### PR DESCRIPTION
See: https://docs.npmjs.com/misc/faq#if-npm-is-an-acronym-why-is-it-never-capitalized

A trivial change, but thought I'd suggest it anyway.